### PR TITLE
Fix shutdown method

### DIFF
--- a/src/SimpleADB.es6
+++ b/src/SimpleADB.es6
@@ -218,7 +218,7 @@ export class SimpleADB {
      */
     shutdown () {
         this.logger.info('Shutting down');
-        return this.execShellAdbCommand(['input', 'keyevent', 'KEYCODE_POWER']);
+        return this.execAdbShellCommand(['reboot', '-p']);
     }
 
 


### PR DESCRIPTION
For whatever reason, it wasn't working correctly. With this change, sending the shell command "reboot -p" triggers a power down.